### PR TITLE
Add session reconnect so dropped players can reclaim their seat

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -4,3 +4,9 @@ DISCORD_CHANNEL_ID=
 DISCORD_CHANNEL_NAME=
 GAME_URL=https://daktagames.itch.io/exceedgg
 SKIP_MATCH_UPLOAD=1
+# How long a seat in a live game is held for a player who dropped, in ms.
+RECONNECT_GRACE_MS=120000
+# How long a disconnected player's session stays restorable, in ms.
+SESSION_GRACE_MS=600000
+# Websocket ping/keepalive interval, in ms.
+KEEPALIVE_INTERVAL_MS=15000

--- a/.env_template
+++ b/.env_template
@@ -4,6 +4,9 @@ DISCORD_CHANNEL_ID=
 DISCORD_CHANNEL_NAME=
 GAME_URL=https://daktagames.itch.io/exceedgg
 SKIP_MATCH_UPLOAD=1
+# Set to 1 to stop the server replacing public/ with the build from Azure blob
+# storage, so a locally exported web client can be served for testing.
+SKIP_GAME_ZIP_DOWNLOAD=
 # How long a seat in a live game is held for a player who dropped, in ms.
 RECONNECT_GRACE_MS=120000
 # How long a disconnected player's session stays restorable, in ms.

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 
 /.vscode/
 /public/
+/public_azure_backup/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,88 @@
 # Exceed fan game server
 A simple node JS game web server app for the exceed fan game client.
 Run locally with: node server.js
+
+Run the tests with: npm test
+
+## Sessions and reconnecting
+
+A websocket connection and a player session are separate things. Every player
+gets a session that outlives its websocket, so a client that drops out of a
+game can come back and reclaim its seat.
+
+There are no accounts, so the server cannot recognise a returning client on its
+own. Instead the client holds a credential and presents it on reconnect.
+
+### Handshake
+
+`server_hello` (and `name_update`) carry the identifiers the client must keep:
+
+| Field | Meaning |
+| --- | --- |
+| `player_id` | Public uuid used throughout the game protocol |
+| `session_id` | Public session handle, safe to log |
+| `session_token` | **Secret.** The only credential accepted for a restore |
+
+The client should persist all three (localStorage on web, `user://` natively).
+
+### Restoring
+
+On reconnect the client sends:
+
+```json
+{
+  "type": "restore_session",
+  "context": {
+    "previous_session_token": "<saved session_token>",
+    "previous_session_id": "<saved session_id>",
+    "previous_player_id": "<saved player_id>"
+  }
+}
+```
+
+The token is the only match key. `previous_session_id` and `previous_player_id`
+are optional consistency checks: if they are supplied and disagree with the
+session the token resolves to, the restore is refused. Names, room ids and IP
+addresses are never used to match a session.
+
+On success the server rebinds the websocket onto the original player object and
+replies with `session_restored`, which contains the restored identity plus
+`room_id`, `in_game`, `queue_id`, `lobby_state`, `opponent_name`,
+`opponent_connected` and `messages`. `messages` is the `game_start` message
+followed by every `game_message`, which is everything the client needs to
+rebuild an in progress game and resume automatically.
+
+On failure the server replies with `session_restore_failed` and a `reason` of
+`missing_session_token`, `no_matching_session`, `session_mismatch` or
+`current_player_missing`. The client should then carry on as a new player.
+
+### Disconnects during a game
+
+| Event | Message | Sent to |
+| --- | --- | --- |
+| A player's connection drops | `player_disconnect_pending` (with `reconnect_deadline`) | The opponent and observers |
+| They restore in time | `player_reconnect` | The opponent and observers |
+| The grace period expires | `player_disconnect` | The room |
+
+The seat is held for `RECONNECT_GRACE_MS`. Nobody else can join it during that
+window; only the holder of the session token can reclaim it. Once the grace
+period expires the player is removed and clients see the same `player_disconnect`
+they always have. A deliberate `leave_room` is immediate and never holds a seat.
+
+### Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `RECONNECT_GRACE_MS` | 120000 | How long a seat in a live game is held |
+| `SESSION_GRACE_MS` | 600000 | How long a session stays restorable (never less than the reconnect grace) |
+| `KEEPALIVE_INTERVAL_MS` | 15000 | Websocket ping interval, also drives `server_keepalive` |
+
+### Other client facing messages
+
+- `server_keepalive` is pushed on the keepalive interval so browser clients,
+  which cannot see websocket level pings, can tell the server is still alive.
+- `request_players_update` asks for a `players_update` on demand instead of
+  waiting for the next broadcast.
+- `players_update` rooms now also report `connected_player_count`, `game_over`
+  and `player_connected`, and queues report `waiting_deck_id` for the character
+  currently sitting in the queue.

--- a/blobstorage.js
+++ b/blobstorage.js
@@ -179,6 +179,10 @@ export async function upload_to_blob_storage(matchData) {
 }
 
 export async function checkAndDownloadUpdatedGameZip(gamePath) {
+    if (process.env.SKIP_GAME_ZIP_DOWNLOAD) {
+        console.warn('SKIP_GAME_ZIP_DOWNLOAD set, serving the existing contents of public/ as-is.');
+        return;
+    }
     if (!process.env.AZURE_STORAGE_CONNECTION_STRING) {
         console.warn('Azure Storage Connection string not found, skipping game zip update');
         return;

--- a/gameroom.js
+++ b/gameroom.js
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { upload_to_blob_storage } from './blobstorage.js';
 
 class GameRoom {
-  constructor(version, room_name, database, starting_timer, enforce_timer, minimum_time_per_choice) {
+  constructor(version, room_name, database, starting_timer, enforce_timer, minimum_time_per_choice, reconnect_grace_ms = 0) {
     this.database = database
     this.name = room_name
     this.players = []
@@ -20,10 +20,37 @@ class GameRoom {
     this.starting_timer = starting_timer
     this.enforce_timer = enforce_timer
     this.minimum_time_per_choice = minimum_time_per_choice
+    this.reconnect_grace_ms = reconnect_grace_ms
   }
 
   get_observer_count() {
     return this.observers.length
+  }
+
+  get_connected_player_count() {
+    return this.players.filter(player => player.connected).length
+  }
+
+  get_disconnected_players() {
+    return this.players.filter(player => !player.connected)
+  }
+
+  has_disconnected_player() {
+    return this.get_disconnected_players().length > 0
+  }
+
+  is_empty() {
+    return this.players.length === 0 && this.observers.length === 0
+  }
+
+  // Messages an already-running game needs in order to rebuild its state.
+  get_replay_messages() {
+    const game_start_message = this.message_log.find(message => message.type === 'game_start')
+    if (!game_start_message) {
+      return []
+    }
+    const game_messages = this.message_log.filter(message => message.type === 'game_message')
+    return [game_start_message, ...game_messages]
   }
 
   get_player_name(index) {
@@ -68,7 +95,7 @@ class GameRoom {
         const message = {
           type: 'room_waiting_for_opponent',
         }
-        player.ws.send(JSON.stringify(message))
+        player.send(message)
       }
       return true
     }
@@ -83,7 +110,7 @@ class GameRoom {
       type: 'observe_start',
       messages: this.message_log
     }
-    player.ws.send(JSON.stringify(message))
+    player.send(message)
     return true
   }
 
@@ -227,18 +254,102 @@ class GameRoom {
   broadcast(message) {
     this.message_log.push(message)
     for (const player of this.players) {
-      message['your_player_id'] = player.id
-      player.ws.send(JSON.stringify(message))
+      // Copy per recipient. Mutating the shared object would leak the last
+      // player's id into the message log and into every observer's copy.
+      player.send({ ...message, your_player_id: player.id })
     }
     for (const player of this.observers) {
-      player.ws.send(JSON.stringify(message))
+      player.send(message)
     }
   }
 
+  // Out of band notifications that are not part of the replayable game log.
+  broadcast_to_peers(source_player, message) {
+    for (const player of this.players) {
+      if (player !== source_player) {
+        player.send(message)
+      }
+    }
+    for (const player of this.observers) {
+      player.send(message)
+    }
+  }
+
+  get_reconnect_deadline(player, reconnect_grace_ms) {
+    if (player.connected || !player.last_disconnect_at) {
+      return null
+    }
+    return player.last_disconnect_at.getTime() + reconnect_grace_ms
+  }
+
+  // An abnormal disconnect during a live game. The seat is held so the player
+  // can reclaim it with their session token before the grace period expires.
+  hold_seat_for_reconnect(player, reconnect_grace_ms) {
+    if (!this.is_player(player) || !this.gameStarted || this.is_game_over) {
+      return false
+    }
+
+    this.disconnects += 1
+    console.log(`Player ${player.name} disconnected from ${this.name}, holding seat for reconnect`)
+    this.broadcast_to_peers(player, {
+      type: 'player_disconnect_pending',
+      id: player.id,
+      name: player.name,
+      player_id: player.id,
+      player_name: player.name,
+      reconnect_deadline: this.get_reconnect_deadline(player, reconnect_grace_ms),
+    })
+    return true
+  }
+
+  player_reconnect(player) {
+    if (!this.is_player(player) || !this.gameStarted) {
+      return false
+    }
+
+    console.log(`Player ${player.name} reconnected to ${this.name}`)
+    this.broadcast_to_peers(player, {
+      type: 'player_reconnect',
+      id: player.id,
+      name: player.name,
+      player_id: player.id,
+      player_name: player.name,
+    })
+    return true
+  }
+
+  // The grace period ran out. Fall back to the pre-reconnect behaviour so
+  // clients see exactly the disconnect they have always seen.
+  expire_held_seat(player) {
+    if (!this.is_player(player)) {
+      return false
+    }
+
+    this.players = this.players.filter(p => p !== player)
+    this.broadcast({
+      type: 'player_disconnect',
+      id: player.id,
+      name: player.name,
+      player_id: player.id,
+      player_name: player.name,
+      reason: 'reconnect_timeout',
+    })
+    if (this.players.length === 0) {
+      this.game_over()
+    }
+    return true
+  }
+
+  // Returns true when the caller should clear the player's room reference.
+  // A held seat returns false so the player can be restored into this game.
   player_quit(player, disconnect) {
     if (this.is_observer(player)) {
       this.observers = this.observers.filter(p => p !== player)
+      return true
     } else if (this.is_player(player)) {
+      if (disconnect && this.gameStarted && !this.is_game_over) {
+        return !this.hold_seat_for_reconnect(player, this.reconnect_grace_ms)
+      }
       if (disconnect) {
         this.disconnects += 1
       }
@@ -246,13 +357,18 @@ class GameRoom {
       const message = {
         type: disconnect ? 'player_disconnect' : 'player_quit',
         id: player.id,
-        name: player.name
+        name: player.name,
+        player_id: player.id,
+        player_name: player.name,
       }
       this.broadcast(message)
       if (this.players.length === 0) {
         this.game_over()
       }
+      return true
     }
+
+    return false
   }
 }
 

--- a/gameroom.js
+++ b/gameroom.js
@@ -334,10 +334,31 @@ class GameRoom {
       player_name: player.name,
       reason: 'reconnect_timeout',
     })
+    this.end_game_if_not_enough_players()
+    return true
+  }
+
+  // A two player game cannot continue once a seat is permanently vacated, so
+  // the room must not keep advertising itself as a live match that somebody
+  // could be restored back into.
+  end_game_if_not_enough_players() {
     if (this.players.length === 0) {
       this.game_over()
+      return
     }
-    return true
+    if (this.gameStarted && this.players.length < 2) {
+      this.game_over()
+      return
+    }
+    // Held seats keep a player in this.players, so a room where everybody has
+    // disconnected still looks like a live match. Nobody is waiting for a
+    // reconnect that nobody is present to complete, and restoring into it
+    // strands the returning player in an inescapable "waiting for opponent"
+    // overlay for a match that no longer exists.
+    if (this.gameStarted && this.get_connected_player_count() === 0) {
+      console.log(`Room ${this.name} has no connected players left, ending the game`)
+      this.game_over()
+    }
   }
 
   // Returns true when the caller should clear the player's room reference.
@@ -348,7 +369,12 @@ class GameRoom {
       return true
     } else if (this.is_player(player)) {
       if (disconnect && this.gameStarted && !this.is_game_over) {
-        return !this.hold_seat_for_reconnect(player, this.reconnect_grace_ms)
+        const seat_held = this.hold_seat_for_reconnect(player, this.reconnect_grace_ms)
+        if (seat_held) {
+          // That may have been the last player present.
+          this.end_game_if_not_enough_players()
+        }
+        return !seat_held
       }
       if (disconnect) {
         this.disconnects += 1
@@ -362,9 +388,7 @@ class GameRoom {
         player_name: player.name,
       }
       this.broadcast(message)
-      if (this.players.length === 0) {
-        this.game_over()
-      }
+      this.end_game_if_not_enough_players()
       return true
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "mssql": "^10.0.2",
         "obscenity": "^0.2.1",
         "unzipper": "^0.12.3",
+        "uuid": "^11.1.0",
         "ws": "^8.14.2"
       }
     },
@@ -128,6 +129,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/core-http/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@azure/core-lro": {
@@ -315,6 +325,15 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@azure/storage-blob": {
@@ -2919,11 +2938,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "type": "module",
+  "scripts": {
+    "test": "node --test test/"
+  },
   "dependencies": {
     "@azure/identity": "^4.2.0",
     "@azure/storage-blob": "^12.18.0",
@@ -11,6 +14,7 @@
     "mssql": "^10.0.2",
     "obscenity": "^0.2.1",
     "unzipper": "^0.12.3",
+    "uuid": "^11.1.0",
     "ws": "^8.14.2"
   }
 }

--- a/player.js
+++ b/player.js
@@ -1,14 +1,31 @@
 class Player {
-    constructor(ws, id, name) {
+    constructor(ws, id, name, session_id, session_token) {
       this.ws = ws
       this.id = id
       this.name = name
+      // session_id is a public handle safe to log/broadcast.
+      // session_token is the secret credential the client presents to restore this session.
+      this.session_id = session_id
+      this.session_token = session_token
       this.timeout = null
       this.deck_id = ""
       this.custom_deck_definition = null
       this.room = null
+      this.queue_id = null
       this.version = "?"
       this.playing_AI = false
+      this.lobby_state = "Lobby"
+      this.connected = true
+      this.last_disconnect_at = null
+      this.awaiting_pong = false
+    }
+
+    get_identity() {
+      return {
+        player_id: this.id,
+        session_id: this.session_id,
+        session_token: this.session_token,
+      }
     }
 
     set_name(version, name) {
@@ -17,8 +34,9 @@ class Player {
       const message = {
           type: 'name_update',
           name: this.name,
+          ...this.get_identity(),
       }
-      this.ws.send(JSON.stringify(message))
+      this.send(message)
     }
 
     set_playing_AI(playing) {
@@ -32,6 +50,39 @@ class Player {
 
     set_room(room) {
       this.room = room
+    }
+
+    attach_connection(ws) {
+      this.ws = ws
+      this.connected = true
+      this.last_disconnect_at = null
+      this.awaiting_pong = false
+    }
+
+    detach_connection() {
+      this.ws = null
+      this.connected = false
+      this.last_disconnect_at = new Date()
+      this.awaiting_pong = false
+    }
+
+    mark_pong() {
+      this.awaiting_pong = false
+    }
+
+    // Sending is a no-op while the player is disconnected but still holding a
+    // seat, so callers never have to null check the websocket.
+    send(message) {
+      if (!this.ws || !this.connected) {
+        return false
+      }
+      try {
+        this.ws.send(JSON.stringify(message))
+        return true
+      } catch (error) {
+        console.log(`Failed to send message to player ${this.id}:`, error)
+        return false
+      }
     }
   }
 

--- a/queue_manager.js
+++ b/queue_manager.js
@@ -53,6 +53,26 @@ export default class QueueManager {
         this.initQueues()
     }
 
+    findDeckConfig(deck_id) {
+        return this.decks.find(deck => deck && typeof deck === 'object' && deck.character === deck_id)
+    }
+
+    // Alternate skins are suffixed with _<n> (e.g. "nanase_2"). They share the
+    // season and ban status of the base character.
+    getBaseDeckId(deck_id) {
+        const skin_match = /^(.+)_([1-9]\d*)$/.exec(deck_id)
+        if (!skin_match) {
+            return deck_id
+        }
+
+        const base_deck_id = skin_match[1]
+        if (this.findDeckConfig(base_deck_id)) {
+            return base_deck_id
+        }
+
+        return deck_id
+    }
+
     validateDeck(queue_id, deck_id) {
         // If the player picks random, their deck_id is random_*#deck_id
         // Where * is either s1, s2, etc. or just plain random#deck_id if all season random.
@@ -70,7 +90,8 @@ export default class QueueManager {
             return true
         }
 
-        const deck = this.decks.find(deck => deck.character === deck_id)
+        const base_deck_id = this.getBaseDeckId(deck_id)
+        const deck = this.findDeckConfig(base_deck_id)
         if (!deck) {
             console.log(`Couldn't find deck ${deck_id}`)
             return false
@@ -80,7 +101,7 @@ export default class QueueManager {
             return false
         }
 
-        if (queue.banned.includes(deck_id)) {
+        if (queue.banned.includes(deck_id) || queue.banned.includes(base_deck_id)) {
             return false
         }
 
@@ -95,15 +116,57 @@ export default class QueueManager {
         return true
     }
 
+    // The character the lone queued player picked, so the lobby can show it.
+    getVisibleWaitingDeckId(queue) {
+        if (!queue.waiting_room || queue.waiting_room.players.length !== 1) {
+            return ""
+        }
+
+        const waiting_player = queue.waiting_room.players[0]
+        if (!waiting_player || typeof waiting_player.deck_id !== 'string') {
+            return ""
+        }
+
+        if (waiting_player.deck_id.startsWith('random') && waiting_player.deck_id.includes('#')) {
+            return waiting_player.deck_id.split('#')[1] || waiting_player.deck_id
+        }
+
+        return waiting_player.deck_id
+    }
+
     getQueueInfos() {
         // Each queue has id, name, and match_available fields.
         return this.queues.map(queue => {
-            return {
+            const queue_info = {
                 id: queue.id,
                 name: queue.name,
                 match_available: queue.waiting_room !== null
             }
+
+            const waiting_deck_id = this.getVisibleWaitingDeckId(queue)
+            if (queue_info.match_available && waiting_deck_id) {
+                queue_info.waiting_deck_id = waiting_deck_id
+            }
+
+            return queue_info
         })
+    }
+
+    // Clears waiting rooms whose queued player is no longer reachable, so the
+    // lobby never advertises a match that cannot be joined.
+    pruneStaleQueues(is_player_alive) {
+        for (const queue of this.queues) {
+            if (!queue.waiting_room) {
+                continue
+            }
+            if (!queue.waiting_room.players.some(player => is_player_alive(player))) {
+                for (const player of queue.waiting_room.players) {
+                    player.queue_id = null
+                }
+                this.room_manager.deleteRoom(queue.waiting_room.name)
+                queue.waiting_room = null
+            }
+        }
     }
 
     addPlayer(queue_id, player, player_join_version) {
@@ -114,20 +177,23 @@ export default class QueueManager {
         }
 
         var success = false
+        player.queue_id = queue_id
         if (queue.waiting_room) {
             // A room already exists for this match.
             if (queue.waiting_room.version < player_join_version) {
                 // The player joining has a larger version,
                 // kick the player in the room and make a new one.
                 var player_in_room = queue.waiting_room.players[0]
-                send_join_version_error(player_in_room.ws)
+                send_join_version_error(player_in_room)
+                player_in_room.queue_id = null
                 this.room_manager.leaveRoom(player_in_room, false)
                 queue.waiting_room = this.createNewMatchRoom(queue, player_join_version, player)
                 success = true
             } else if (queue.waiting_room.version > player_join_version) {
                 // Lower version than room, probably need to update.
                 // Send error message.
-                send_join_version_error(ws)
+                send_join_version_error(player)
+                player.queue_id = null
                 return true
             } else {
                 // Join the room successfully.
@@ -160,10 +226,12 @@ export default class QueueManager {
         for (const queue of this.queues) {
             if (queue.waiting_room) {
                 if (queue.waiting_room.is_player(player)) {
+                    this.room_manager.deleteRoom(queue.waiting_room.name)
                     queue.waiting_room = null
                 }
             }
         }
+        player.queue_id = null
     }
 
     createNewMatchRoom(queue, version, player) {
@@ -194,10 +262,10 @@ export default class QueueManager {
     }
 }
 
-function send_join_version_error(ws) {
+function send_join_version_error(player) {
     const message = {
         type: 'room_join_failed',
         reason: 'version_mismatch'
     }
-    ws.send(JSON.stringify(message))
+    player.send(message)
 }

--- a/room_manager.js
+++ b/room_manager.js
@@ -1,8 +1,9 @@
 import GameRoom from './gameroom.js'
 
 export default class RoomManager {
-    constructor() {
+    constructor(reconnect_grace_ms = 0) {
         this.rooms = {}
+        this.reconnect_grace_ms = reconnect_grace_ms
     }
 
     getRoomInfos() {
@@ -11,18 +12,23 @@ export default class RoomManager {
         //     room_name
         //     room_version
         //     player_count
+        //     connected_player_count
         //     observer_count
         //     game_started
+        //     game_over
         //     player_names
         //     player_decks
+        //     player_connected
         // }
-        return Object.values(this.rooms).map(room => {
+        return Object.values(this.rooms).filter(room => !room.is_empty()).map(room => {
             return {
                 room_name: room.name,
                 room_version: room.version,
                 player_count: room.players.length,
+                connected_player_count: room.get_connected_player_count(),
                 observer_count: room.get_observer_count(),
                 game_started: room.gameStarted,
+                game_over: room.is_game_over,
                 player_names: [
                     room.get_player_name(0),
                     room.get_player_name(1)
@@ -30,6 +36,10 @@ export default class RoomManager {
                 player_decks: [
                     room.get_player_deck(0),
                     room.get_player_deck(1)
+                ],
+                player_connected: [
+                    room.players.length > 0 ? room.players[0].connected : false,
+                    room.players.length > 1 ? room.players[1].connected : false,
                 ],
                 player_custom_deck_portraits: [
                     room.get_player_custom_deck_portrait(0),
@@ -43,6 +53,15 @@ export default class RoomManager {
         return this.rooms[room_name]
     }
 
+    // Accepts either the internal room name or the name a client would send,
+    // which omits the "custom_" prefix added by the custom room flow.
+    findRoomByJoinId(room_name) {
+        if (this.rooms[room_name]) {
+            return this.rooms[room_name]
+        }
+        return this.rooms[`custom_${room_name}`]
+    }
+
     addRoom(
         player_join_version,
         room_name,
@@ -51,20 +70,29 @@ export default class RoomManager {
         enforce_timer,
         minimum_time_per_choice
     ) {
-        this.rooms[room_name] = new GameRoom(player_join_version, room_name, database, starting_timer, enforce_timer, minimum_time_per_choice)
+        this.rooms[room_name] = new GameRoom(
+            player_join_version,
+            room_name,
+            database,
+            starting_timer,
+            enforce_timer,
+            minimum_time_per_choice,
+            this.reconnect_grace_ms
+        )
         return this.rooms[room_name]
     }
 
     leaveRoom(player, disconnect) {
         if (player.room !== null) {
-            var room_name = player.room.name
-            player.room.player_quit(player, disconnect)
-            if (player.room.is_game_over) {
-                console.log("Closing room " + room_name)
-                this.rooms[room_name].close_room()
-                delete this.rooms[room_name]
+            const room = player.room
+            const should_leave_room = room.player_quit(player, disconnect)
+            if (should_leave_room) {
+                player.room = null
             }
-            player.room = null
+            if (room.is_empty()) {
+                console.log("Closing room " + room.name)
+                this.deleteRoom(room.name)
+            }
         }
     }
 
@@ -73,5 +101,51 @@ export default class RoomManager {
             this.rooms[room_name].close_room()
             delete this.rooms[room_name]
         }
+    }
+
+    // Removes players whose connection died without a clean close, expires seats
+    // held past the reconnect grace period, and deletes rooms nobody is left in.
+    // Callers are expected to have already detached dead connections so that
+    // player.connected and player.last_disconnect_at are accurate.
+    // Returns true when anything visible to the lobby changed.
+    sweep(is_player_alive, now = Date.now()) {
+        var changed = false
+        for (const room of Object.values(this.rooms)) {
+            for (const observer of [...room.observers]) {
+                if (!is_player_alive(observer)) {
+                    room.player_quit(observer, true)
+                    observer.room = null
+                    changed = true
+                }
+            }
+
+            for (const player of [...room.players]) {
+                if (is_player_alive(player)) {
+                    continue
+                }
+                if (!room.gameStarted || room.is_game_over) {
+                    // No live game to come back to, so treat it as a plain quit.
+                    room.player_quit(player, true)
+                    player.room = null
+                    changed = true
+                    continue
+                }
+                const deadline = room.get_reconnect_deadline(player, this.reconnect_grace_ms)
+                if (deadline === null || now >= deadline) {
+                    room.expire_held_seat(player)
+                    player.room = null
+                    changed = true
+                }
+            }
+        }
+
+        for (const room_name of Object.keys(this.rooms)) {
+            if (this.rooms[room_name].is_empty()) {
+                this.deleteRoom(room_name)
+                changed = true
+            }
+        }
+
+        return changed
     }
 }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 import { WebSocketServer } from 'ws'
+import { v4 as uuidv4 } from 'uuid'
 import {
 	RegExpMatcher,
 	TextCensor,
@@ -10,6 +11,13 @@ import Database from './dbaccess.js'
 import QueueManager from './queue_manager.js'
 import RoomManager from './room_manager.js';
 import DiscordConnection from './discordconnection.js';
+import {
+  build_player_state_snapshot,
+  build_server_hello_message,
+  build_server_keepalive_message,
+  build_session_restore_failed_message,
+  build_session_restored_message,
+} from './session_messages.js'
 import { get_server_config, update_customs_db, checkAndDownloadUpdatedGameZip } from './blobstorage.js'
 import * as dotenv from 'dotenv';
 dotenv.config({ path: `.env`, debug: true });
@@ -49,7 +57,21 @@ const censor = new TextCensor();
 
 // Set player timeout to 15 minutes
 const PlayerTimeoutMs = 15 * 60 * 1000 * 99
+// How long a seat in a live game is held for a player who dropped.
+const ReconnectGraceMs = parseInt(process.env.RECONNECT_GRACE_MS) || 2 * 60 * 1000
+// How long a disconnected player's identity stays restorable.
+const SessionGraceMs = Math.max(
+  parseInt(process.env.SESSION_GRACE_MS) || 10 * 60 * 1000,
+  ReconnectGraceMs
+)
+const KeepaliveIntervalMs = parseInt(process.env.KEEPALIVE_INTERVAL_MS) || 15 * 1000
+const SweepIntervalMs = 5 * 1000
+
+// websocket -> the player it is currently bound to.
 const active_connections = new Map()
+// Long lived session indexes. A player outlives its websocket so that a
+// reconnecting client can be put back into the game it dropped out of.
+const sessions_by_token = new Map()
 
 const sqltimeout = 30000
 const config = {
@@ -72,7 +94,7 @@ const config = {
 const discord_connection = new DiscordConnection()
 const database = new Database(config);
 const server_config = await get_server_config()
-const room_manager = new RoomManager()
+const room_manager = new RoomManager(ReconnectGraceMs)
 const queue_manager = new QueueManager(database, server_config, discord_connection, room_manager)
 var customs_db = {
   version: 0,
@@ -94,6 +116,231 @@ setInterval(async () => {
 
 var running_id = 1
 var check_value = process.env.CHECK_VALUE
+
+// ---------------------------------------------------------------------------
+// Session and connection management
+// ---------------------------------------------------------------------------
+
+function create_player(ws) {
+  const player = new Player(ws, uuidv4(), "Anon_" + get_next_id(), uuidv4(), uuidv4())
+  sessions_by_token.set(player.session_token, player)
+  return player
+}
+
+function unregister_player(player) {
+  if (!player) {
+    return
+  }
+  if (sessions_by_token.get(player.session_token) === player) {
+    sessions_by_token.delete(player.session_token)
+  }
+}
+
+function get_player_for_ws(ws) {
+  return active_connections.get(ws)
+}
+
+function get_connected_players() {
+  return Array.from(new Set(active_connections.values()))
+}
+
+function attach_connection_to_player(ws, player) {
+  player.attach_connection(ws)
+  active_connections.set(ws, player)
+}
+
+function detach_player_connection(player) {
+  if (player.ws && active_connections.get(player.ws) === player) {
+    active_connections.delete(player.ws)
+  }
+  clear_player_timeout(player)
+  player.detach_connection()
+}
+
+function clear_player_timeout(player) {
+  if (player.timeout !== null) {
+    clearTimeout(player.timeout)
+    player.timeout = null
+  }
+}
+
+function is_player_connection_alive(player) {
+  return !!(
+    player &&
+    player.connected &&
+    player.ws &&
+    player.ws.readyState === 1 &&
+    active_connections.get(player.ws) === player
+  )
+}
+
+function send_message(ws, message) {
+  try {
+    ws.send(JSON.stringify(message))
+  } catch (error) {
+    console.log("Failed to send message:", error)
+  }
+}
+
+// Sockets that died without a clean close leave a player marked connected.
+// Detaching them here starts the reconnect clock and runs the same cleanup a
+// clean close would, so nothing is left holding a stale queue or room slot.
+function detach_dead_connections() {
+  for (const [ws, player] of [...active_connections.entries()]) {
+    if (ws.readyState === 1) {
+      continue
+    }
+    active_connections.delete(ws)
+    if (player.ws !== ws) {
+      continue
+    }
+    clear_player_timeout(player)
+    player.detach_connection()
+    queue_manager.leaveRoom(player)
+    room_manager.leaveRoom(player, true)
+  }
+}
+
+function sweep_state(now = Date.now()) {
+  detach_dead_connections()
+  queue_manager.pruneStaleQueues(is_player_connection_alive)
+  const rooms_changed = room_manager.sweep(is_player_connection_alive, now)
+
+  for (const player of [...sessions_by_token.values()]) {
+    if (is_player_connection_alive(player)) {
+      continue
+    }
+    if (player.room || player.queue_id) {
+      continue
+    }
+    if (!player.last_disconnect_at) {
+      continue
+    }
+    if (now - player.last_disconnect_at.getTime() <= SessionGraceMs) {
+      continue
+    }
+    unregister_player(player)
+  }
+
+  return rooms_changed
+}
+
+function get_public_room_name(room) {
+  if (!room) {
+    return null
+  }
+  if (room.name.startsWith("custom_")) {
+    return room.name.substring("custom_".length)
+  }
+  return room.name
+}
+
+function send_restore_failed(ws, reason, details = {}) {
+  send_message(ws, build_session_restore_failed_message(reason, details))
+}
+
+// Rebinds a websocket onto a previously created player session. The session
+// token is the only accepted credential: it is the one thing that proves the
+// caller is the same client that owned the session.
+function restore_session(ws, json_data) {
+  if (typeof json_data !== 'object' || json_data === null) {
+    return false
+  }
+
+  const current_player = get_player_for_ws(ws)
+  if (!current_player) {
+    send_restore_failed(ws, 'current_player_missing')
+    return true
+  }
+
+  const context = typeof json_data.context === 'object' && json_data.context !== null
+    ? json_data.context
+    : json_data
+  const previous_session_token = context.previous_session_token
+
+  if (typeof previous_session_token !== 'string' || previous_session_token.length === 0) {
+    send_restore_failed(ws, 'missing_session_token')
+    return true
+  }
+
+  // Expire anything that is already past its grace period before matching, so
+  // a stale session is never resurrected.
+  sweep_state()
+
+  const old_player = sessions_by_token.get(previous_session_token)
+  if (!old_player) {
+    console.log(`[restore_session] failed: no session for the supplied token`)
+    send_restore_failed(ws, 'no_matching_session')
+    return true
+  }
+
+  // Optional consistency checks. These are not match keys, they only catch a
+  // client sending a token that disagrees with the rest of its saved state.
+  if (context.previous_player_id && String(context.previous_player_id) !== String(old_player.id)) {
+    send_restore_failed(ws, 'session_mismatch', { field: 'previous_player_id' })
+    return true
+  }
+  if (context.previous_session_id && context.previous_session_id !== old_player.session_id) {
+    send_restore_failed(ws, 'session_mismatch', { field: 'previous_session_id' })
+    return true
+  }
+
+  if (old_player === current_player) {
+    // Nothing to merge, but the client still wants its current state.
+    send_message(ws, build_session_restored_message(
+      old_player,
+      null,
+      build_player_state_snapshot(old_player, get_public_room_name)
+    ))
+    return true
+  }
+
+  console.log(`[restore_session] attempt: temporary_player=${current_player.id} target_session=${old_player.session_id} target_player=${old_player.id}/${old_player.name}`)
+
+  // The token holder owns the session, so an older connection still holding it
+  // (a duplicate tab, or a socket the server has not noticed is dead) loses.
+  if (old_player.ws && old_player.ws !== ws) {
+    console.log(`[restore_session] replacing_connection: player=${old_player.id}`)
+    const replaced_ws = old_player.ws
+    active_connections.delete(replaced_ws)
+    try {
+      replaced_ws.close()
+    } catch (error) {
+      console.log("Failed to close replaced websocket during restore:", error)
+    }
+  }
+
+  if (current_player.version !== "?") {
+    old_player.version = current_player.version
+  }
+
+  // Drop the throwaway identity this websocket was given on connect. Detaching
+  // it first releases the websocket and cancels its idle timeout, which would
+  // otherwise fire later and close the restored player's connection.
+  remove_player_from_all_state(current_player)
+  detach_player_connection(current_player)
+  unregister_player(current_player)
+
+  attach_connection_to_player(ws, old_player)
+  set_player_timeout(old_player)
+
+  const snapshot = build_player_state_snapshot(old_player, get_public_room_name)
+  send_message(ws, build_session_restored_message(old_player, current_player, snapshot))
+
+  if (old_player.room && old_player.room.gameStarted) {
+    old_player.room.player_reconnect(old_player)
+  }
+
+  console.log(`[restore_session] success: player=${old_player.id}/${old_player.name} room=${snapshot.room_id ?? 'Lobby'} in_game=${snapshot.in_game}`)
+  broadcast_players_update()
+  return true
+}
+
+function remove_player_from_all_state(player) {
+  queue_manager.leaveRoom(player)
+  room_manager.leaveRoom(player, false)
+  player.lobby_state = "Lobby"
+}
 
 function join_custom_room(ws, join_room_json) {
   // join_room_json required parameters:
@@ -125,7 +372,7 @@ function join_custom_room(ws, join_room_json) {
   }
   var player_join_version = join_room_json.version
 
-  var player = active_connections.get(ws)
+  var player = get_player_for_ws(ws)
   if (player === undefined) {
     console.log("join_room Player is undefined")
     return false
@@ -241,7 +488,7 @@ function observe_room(ws, json_data) {
   }
   var player_join_version = json_data.version
 
-  var player = active_connections.get(ws)
+  var player = get_player_for_ws(ws)
   if (player === undefined) {
     console.log("observe_room Player is undefined")
     return false
@@ -264,10 +511,7 @@ function observe_room(ws, json_data) {
 
   // Find the match.
   // Search for the match as is, or with the custom_ prefix.
-  var room = room_manager.findRoom(room_name)
-  if (!room) {
-    room = room_manager.findRoom("custom_" + room_name)
-  }
+  var room = room_manager.findRoomByJoinId(room_name)
 
   if (room) {
     if (room.version != player_join_version) {
@@ -335,7 +579,7 @@ function join_matchmaking(ws, json_data) {
 
   var player_join_version = json_data.version
 
-  var player = active_connections.get(ws)
+  var player = get_player_for_ws(ws)
   if (player === undefined) {
     console.log("join_matchmaking Player is undefined")
     return false
@@ -378,7 +622,6 @@ function join_matchmaking(ws, json_data) {
     }
   }
 
-  var player = active_connections.get(ws)
   player.set_deck_id(deck_id, custom_deck_definition)
   var success = queue_manager.addPlayer(queue_id, player, player_join_version)
 
@@ -422,21 +665,30 @@ function send_paged_customs(ws) {
 function leave_room(player, disconnect) {
   queue_manager.leaveRoom(player)
   room_manager.leaveRoom(player, disconnect)
+  if (!disconnect) {
+    player.lobby_state = "Lobby"
+  }
   broadcast_players_update()
 }
 
 function handle_disconnect(ws) {
-  const player = active_connections.get(ws)
-  if (player) {
-    console.log(`Player ${player.name} disconnected`)
-    leave_room(player, true)
-    active_connections.delete(ws)
-    broadcast_players_update()
+  const player = get_player_for_ws(ws)
+  if (!player) {
+    return
   }
+
+  console.log(`Player ${player.name} disconnected`)
+  detach_player_connection(player)
+  // A player who drops out of a live game keeps their seat until the reconnect
+  // grace period expires. Everything else is cleaned up immediately.
+  queue_manager.leaveRoom(player)
+  room_manager.leaveRoom(player, true)
+  sweep_state()
+  broadcast_players_update()
 }
 
 function already_has_player_with_name(player_to_ignore, name) {
-  for (const player of active_connections.values()) {
+  for (const player of get_connected_players()) {
     if (player === player_to_ignore) {
       continue
     }
@@ -481,6 +733,7 @@ function set_lobby_state(player, json_message) {
     return false
   }
   var lobby_state = json_message.lobby_state
+  player.lobby_state = lobby_state
   if (lobby_state == "AI") {
     player.set_playing_AI(true)
   } else {
@@ -489,14 +742,14 @@ function set_lobby_state(player, json_message) {
   broadcast_players_update()
 }
 
-function broadcast_players_update() {
+function build_players_update_message() {
   const message = {
     type: 'players_update',
     players: [],
     rooms: [],
     queues: queue_manager.getQueueInfos(),
   }
-  for (const player of active_connections.values()) {
+  for (const player of get_connected_players()) {
     var room_name = "Lobby"
     if (player.room !== null) {
       room_name = player.room.name
@@ -512,9 +765,19 @@ function broadcast_players_update() {
     })
   }
   message.rooms = room_manager.getRoomInfos()
-  for (const player of active_connections.values()) {
-    player.ws.send(JSON.stringify(message))
+  return message
+}
+
+function broadcast_players_update() {
+  const message = build_players_update_message()
+  for (const player of get_connected_players()) {
+    player.send(message)
   }
+}
+
+function send_players_update(ws) {
+  send_message(ws, build_players_update_message())
+  return true
 }
 
 function set_player_timeout(player) {
@@ -524,7 +787,9 @@ function set_player_timeout(player) {
   player.timeout = setTimeout(() => {
     console.log("Timing out")
     console.log(`Player ${player.name} timed out`)
-    player.ws.close()
+    if (player.ws) {
+      player.ws.close()
+    }
   }, PlayerTimeoutMs)
 }
 
@@ -537,15 +802,18 @@ function get_next_id() {
 }
 
 wss.on('connection', function connection(ws) {
-  var new_player_id = get_next_id()
-  var player_name = "Anon_" + new_player_id
-  const player = new Player(ws, new_player_id, player_name)
-  active_connections.set(ws, player)
+  const player = create_player(ws)
+  attach_connection_to_player(ws, player)
   set_player_timeout(player)
 
   ws.on('message', function message(data) {
     var handled = false
-    set_player_timeout(player)
+    // The player bound to this websocket can change: a successful
+    // restore_session swaps the temporary player for the restored one.
+    const bound_player = get_player_for_ws(ws)
+    if (bound_player) {
+      set_player_timeout(bound_player)
+    }
     try {
       const json_data = JSON.parse(data)
       const message_type = json_data.type
@@ -555,22 +823,30 @@ wss.on('connection', function connection(ws) {
         handled = observe_room(ws, json_data)
       } else if (message_type == "join_matchmaking") {
         handled = join_matchmaking(ws, json_data)
+      } else if (message_type == "restore_session") {
+        handled = restore_session(ws, json_data)
       } else if (message_type == "set_name") {
-        set_name(player, json_data)
-        handled = true
-      } else if (message_type == "set_lobby_state") {
-        set_lobby_state(player, json_data)
-        handled = true
-      } else if (message_type == "leave_room") {
-        leave_room(player, false)
-        handled = true
-      } else if (message_type == "observe_room") {
-        handled = observe_room(player, json_data)
-      } else if (message_type == "game_message") {
-        if (player.room !== null) {
-          player.room.handle_game_message(player, json_data)
+        if (bound_player) {
+          set_name(bound_player, json_data)
         }
         handled = true
+      } else if (message_type == "set_lobby_state") {
+        if (bound_player) {
+          set_lobby_state(bound_player, json_data)
+        }
+        handled = true
+      } else if (message_type == "leave_room") {
+        if (bound_player) {
+          leave_room(bound_player, false)
+        }
+        handled = true
+      } else if (message_type == "game_message") {
+        if (bound_player && bound_player.room !== null) {
+          bound_player.room.handle_game_message(bound_player, json_data)
+        }
+        handled = true
+      } else if (message_type == "request_players_update") {
+        handled = send_players_update(ws)
       } else if (message_type == "get_customs") {
         handled = send_paged_customs(ws)
       }
@@ -588,12 +864,54 @@ wss.on('connection', function connection(ws) {
     handle_disconnect(ws)
   })
 
-  const message = {
-    type: 'server_hello',
-    player_name: player_name
-  }
-  ws.send(JSON.stringify(message))
+  ws.on('error', (error) => {
+    console.log("Websocket error:", error)
+    handle_disconnect(ws)
+  })
+
+  ws.on('pong', () => {
+    const bound_player = get_player_for_ws(ws)
+    if (bound_player) {
+      bound_player.mark_pong()
+    }
+  })
+
+  send_message(ws, build_server_hello_message(player))
   broadcast_players_update()
 })
+
+// Detect half open connections quickly instead of waiting for TCP to notice.
+// The server_keepalive message additionally lets browser clients, which cannot
+// observe websocket level pings, tell that the server is still there.
+setInterval(() => {
+  const keepalive_message = build_server_keepalive_message()
+  for (const [ws, player] of [...active_connections.entries()]) {
+    if (ws.readyState !== 1) {
+      continue
+    }
+    if (player.awaiting_pong) {
+      console.log(`Player ${player.name} missed a keepalive pong, terminating connection`)
+      ws.terminate()
+      continue
+    }
+    player.awaiting_pong = true
+    try {
+      ws.ping()
+      ws.send(JSON.stringify(keepalive_message))
+    } catch (error) {
+      console.log(`Failed to send keepalive to player ${player.id}:`, error)
+      ws.terminate()
+    }
+  }
+}, KeepaliveIntervalMs)
+
+// Expire held seats and stale sessions even when nothing else is happening.
+setInterval(() => {
+  const player_count_before = get_connected_players().length
+  const rooms_changed = sweep_state()
+  if (rooms_changed || get_connected_players().length !== player_count_before) {
+    broadcast_players_update()
+  }
+}, SweepIntervalMs)
 
 console.log("Server started on port " + port + ".")

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ import {
   build_server_keepalive_message,
   build_session_restore_failed_message,
   build_session_restored_message,
+  build_session_replaced_message,
 } from './session_messages.js'
 import { get_server_config, update_customs_db, checkAndDownloadUpdatedGameZip } from './blobstorage.js'
 import * as dotenv from 'dotenv';
@@ -290,7 +291,7 @@ function restore_session(ws, json_data) {
     send_message(ws, build_session_restored_message(
       old_player,
       null,
-      build_player_state_snapshot(old_player, get_public_room_name)
+      build_player_state_snapshot(old_player, get_public_room_name, ReconnectGraceMs)
     ))
     return true
   }
@@ -303,6 +304,10 @@ function restore_session(ws, json_data) {
     console.log(`[restore_session] replacing_connection: player=${old_player.id}`)
     const replaced_ws = old_player.ws
     active_connections.delete(replaced_ws)
+    // Tell the loser why it is being closed. Without this the close looks like
+    // a network blip, so it auto reconnects and steals the session back, and
+    // the two clients bounce each other forever.
+    send_message(replaced_ws, build_session_replaced_message(old_player))
     try {
       replaced_ws.close()
     } catch (error) {
@@ -324,7 +329,7 @@ function restore_session(ws, json_data) {
   attach_connection_to_player(ws, old_player)
   set_player_timeout(old_player)
 
-  const snapshot = build_player_state_snapshot(old_player, get_public_room_name)
+  const snapshot = build_player_state_snapshot(old_player, get_public_room_name, ReconnectGraceMs)
   send_message(ws, build_session_restored_message(old_player, current_player, snapshot))
 
   if (old_player.room && old_player.room.gameStarted) {

--- a/session_messages.js
+++ b/session_messages.js
@@ -1,0 +1,61 @@
+// Builders for the session restore protocol, kept separate so they can be
+// unit tested without standing up a websocket server.
+
+export function build_server_hello_message(player) {
+  return {
+    type: 'server_hello',
+    player_name: player.name,
+    ...player.get_identity(),
+  }
+}
+
+export function build_session_restore_failed_message(reason, details = {}) {
+  return {
+    type: 'session_restore_failed',
+    reason,
+    ...details,
+  }
+}
+
+// Everything the client needs to put itself back where it was.
+export function build_player_state_snapshot(player, get_public_room_name) {
+  const room = player.room
+  const is_room_player = !!(room && room.is_player(player))
+  const in_game = !!(room && room.gameStarted && is_room_player)
+  const opponent = in_game
+    ? room.players.find(room_player => room_player !== player) ?? null
+    : null
+
+  return {
+    player_id: player.id,
+    player_name: player.name,
+    session_id: player.session_id,
+    session_token: player.session_token,
+    room_id: room ? get_public_room_name(room) : null,
+    room_version: room ? room.version : null,
+    queue_id: player.queue_id,
+    lobby_state: player.lobby_state,
+    observing: !!(room && room.is_observer(player)),
+    in_game,
+    game_over: in_game ? room.is_game_over : false,
+    opponent_name: opponent ? opponent.name : null,
+    opponent_connected: opponent ? opponent.connected : null,
+    messages: in_game ? room.get_replay_messages() : [],
+  }
+}
+
+export function build_session_restored_message(restored_player, temporary_player, snapshot) {
+  return {
+    type: 'session_restored',
+    restored_player_id: restored_player.id,
+    removed_temporary_player_id: temporary_player ? temporary_player.id : null,
+    ...snapshot,
+  }
+}
+
+export function build_server_keepalive_message(now = Date.now()) {
+  return {
+    type: 'server_keepalive',
+    server_time: now,
+  }
+}

--- a/session_messages.js
+++ b/session_messages.js
@@ -18,7 +18,7 @@ export function build_session_restore_failed_message(reason, details = {}) {
 }
 
 // Everything the client needs to put itself back where it was.
-export function build_player_state_snapshot(player, get_public_room_name) {
+export function build_player_state_snapshot(player, get_public_room_name, reconnect_grace_ms = 0) {
   const room = player.room
   const is_room_player = !!(room && room.is_player(player))
   const in_game = !!(room && room.gameStarted && is_room_player)
@@ -40,6 +40,11 @@ export function build_player_state_snapshot(player, get_public_room_name) {
     game_over: in_game ? room.is_game_over : false,
     opponent_name: opponent ? opponent.name : null,
     opponent_connected: opponent ? opponent.connected : null,
+    // Lets a restoring client show the same countdown as a client that was
+    // present for the original player_disconnect_pending broadcast.
+    opponent_reconnect_deadline: opponent
+      ? room.get_reconnect_deadline(opponent, reconnect_grace_ms)
+      : null,
     messages: in_game ? room.get_replay_messages() : [],
   }
 }
@@ -50,6 +55,17 @@ export function build_session_restored_message(restored_player, temporary_player
     restored_player_id: restored_player.id,
     removed_temporary_player_id: temporary_player ? temporary_player.id : null,
     ...snapshot,
+  }
+}
+
+// Sent to a connection that is losing ownership of its session to a newer
+// connection, so it can stop trying to reclaim it.
+export function build_session_replaced_message(player) {
+  return {
+    type: 'session_replaced',
+    player_id: player.id,
+    session_id: player.session_id,
+    reason: 'opened_elsewhere',
   }
 }
 

--- a/test/reconnect.test.js
+++ b/test/reconnect.test.js
@@ -1,0 +1,382 @@
+process.env.SKIP_MATCH_UPLOAD = '1'
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { v4 as uuidv4 } from 'uuid'
+
+import Player from '../player.js'
+import RoomManager from '../room_manager.js'
+import QueueManager from '../queue_manager.js'
+import {
+  build_player_state_snapshot,
+  build_server_hello_message,
+  build_session_restore_failed_message,
+  build_session_restored_message,
+} from '../session_messages.js'
+
+const GRACE_MS = 60 * 1000
+const database = { isEnabled: () => false }
+
+function make_socket() {
+  return {
+    readyState: 1,
+    sent: [],
+    closed: false,
+    send(payload) {
+      this.sent.push(JSON.parse(payload))
+    },
+    close() {
+      this.closed = true
+      this.readyState = 3
+    },
+    messages_of_type(type) {
+      return this.sent.filter(message => message.type === type)
+    },
+  }
+}
+
+function make_player(name, deck_id = "deck") {
+  const socket = make_socket()
+  const player = new Player(socket, uuidv4(), name, uuidv4(), uuidv4())
+  player.version = "test"
+  player.set_deck_id(deck_id, null)
+  return player
+}
+
+function is_alive(player) {
+  return !!(player && player.connected && player.ws && player.ws.readyState === 1)
+}
+
+function get_public_room_name(room) {
+  if (!room) {
+    return null
+  }
+  return room.name.startsWith('custom_') ? room.name.substring('custom_'.length) : room.name
+}
+
+function make_started_room(room_manager, room_name = "custom_room") {
+  const room = room_manager.addRoom("test", room_name, database, 900, false, 30)
+  const player_one = make_player("Alice")
+  const player_two = make_player("Bob")
+  room.join(player_one)
+  room.join(player_two)
+  assert.equal(room.gameStarted, true)
+  return { room, player_one, player_two }
+}
+
+test('broadcast gives each player their own id without polluting the log', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { room, player_one, player_two } = make_started_room(room_manager)
+
+  const game_start_one = player_one.ws.messages_of_type('game_start')[0]
+  const game_start_two = player_two.ws.messages_of_type('game_start')[0]
+  assert.equal(game_start_one.your_player_id, player_one.id)
+  assert.equal(game_start_two.your_player_id, player_two.id)
+  assert.equal('your_player_id' in room.message_log[0], false)
+})
+
+test('disconnecting mid game holds the seat and warns the opponent', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { room, player_one, player_two } = make_started_room(room_manager)
+
+  player_one.detach_connection()
+  room_manager.leaveRoom(player_one, true)
+
+  assert.equal(room.players.length, 2, 'the seat is kept for a reconnect')
+  assert.equal(player_one.room, room, 'the player keeps their room reference')
+  assert.equal(room.get_connected_player_count(), 1)
+
+  const pending = player_two.ws.messages_of_type('player_disconnect_pending')
+  assert.equal(pending.length, 1)
+  assert.equal(pending[0].player_id, player_one.id)
+  assert.ok(pending[0].reconnect_deadline > Date.now())
+  assert.equal(player_two.ws.messages_of_type('player_disconnect').length, 0)
+  assert.equal(room.message_log.some(message => message.type === 'player_disconnect_pending'), false)
+})
+
+test('reconnecting before the grace period restores the seat', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { room, player_one, player_two } = make_started_room(room_manager)
+
+  player_one.detach_connection()
+  room_manager.leaveRoom(player_one, true)
+
+  const new_socket = make_socket()
+  player_one.attach_connection(new_socket)
+  room.player_reconnect(player_one)
+
+  assert.equal(room.get_connected_player_count(), 2)
+  assert.equal(player_two.ws.messages_of_type('player_reconnect').length, 1)
+
+  room_manager.sweep(is_alive, Date.now() + GRACE_MS * 10)
+  assert.equal(room.players.length, 2, 'a reconnected player is never swept')
+})
+
+test('a held seat survives until the grace period expires', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { room, player_one } = make_started_room(room_manager)
+
+  player_one.detach_connection()
+  room_manager.leaveRoom(player_one, true)
+
+  room_manager.sweep(is_alive, Date.now() + GRACE_MS - 1000)
+  assert.equal(room.players.length, 2, 'still inside the grace period')
+})
+
+test('an expired held seat produces the usual player_disconnect', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { room, player_one, player_two } = make_started_room(room_manager)
+
+  player_one.detach_connection()
+  room_manager.leaveRoom(player_one, true)
+  room_manager.sweep(is_alive, Date.now() + GRACE_MS + 1000)
+
+  assert.equal(room.players.length, 1)
+  assert.equal(player_one.room, null)
+  const disconnects = player_two.ws.messages_of_type('player_disconnect')
+  assert.equal(disconnects.length, 1)
+  assert.equal(disconnects[0].player_id, player_one.id)
+  assert.equal(disconnects[0].reason, 'reconnect_timeout')
+})
+
+test('quitting a live game on purpose does not hold a seat', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { room, player_one, player_two } = make_started_room(room_manager)
+
+  room_manager.leaveRoom(player_one, false)
+
+  assert.equal(room.players.length, 1)
+  assert.equal(player_one.room, null)
+  assert.equal(player_two.ws.messages_of_type('player_quit').length, 1)
+  assert.equal(player_two.ws.messages_of_type('player_disconnect_pending').length, 0)
+})
+
+test('a stranger cannot take a held seat', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { room, player_one } = make_started_room(room_manager)
+
+  player_one.detach_connection()
+  room_manager.leaveRoom(player_one, true)
+
+  const intruder = make_player("Mallory")
+  assert.equal(room.join(intruder), false)
+  assert.equal(room.players.includes(intruder), false)
+})
+
+test('a room whose only player drops before the game starts is removed', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const room = room_manager.addRoom("test", "custom_waiting", database, 900, false, 30)
+  const player = make_player("Alice")
+  room.join(player)
+
+  player.detach_connection()
+  room_manager.sweep(is_alive)
+
+  assert.equal(room_manager.findRoom("custom_waiting"), undefined)
+  assert.equal(player.room, null)
+  assert.equal(room_manager.getRoomInfos().length, 0)
+})
+
+test('a dropped observer is pruned and empties the room', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const room = room_manager.addRoom("test", "custom_observed", database, 900, false, 30)
+  const observer = make_player("Watcher")
+  room.observe(observer)
+
+  assert.equal(room.get_observer_count(), 1)
+  observer.detach_connection()
+  room_manager.sweep(is_alive)
+
+  assert.equal(room_manager.findRoom("custom_observed"), undefined)
+  assert.equal(observer.room, null)
+})
+
+test('room infos report connection state and skip empty rooms', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { player_one } = make_started_room(room_manager)
+  room_manager.addRoom("test", "custom_empty", database, 900, false, 30)
+
+  player_one.detach_connection()
+
+  const infos = room_manager.getRoomInfos()
+  assert.equal(infos.length, 1)
+  assert.equal(infos[0].player_count, 2)
+  assert.equal(infos[0].connected_player_count, 1)
+  assert.deepEqual(infos[0].player_connected, [false, true])
+})
+
+test('sweeping reports whether the lobby view changed', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { player_one } = make_started_room(room_manager)
+
+  assert.equal(room_manager.sweep(is_alive), false, 'nothing to do')
+
+  player_one.detach_connection()
+  assert.equal(room_manager.sweep(is_alive, Date.now() + GRACE_MS - 1000), false, 'still held')
+  assert.equal(room_manager.sweep(is_alive, Date.now() + GRACE_MS + 1000), true, 'seat expired')
+})
+
+test('rooms are found by the public name a client sends', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  room_manager.addRoom("test", "custom_myroom", database, 900, false, 30)
+
+  assert.ok(room_manager.findRoomByJoinId("myroom"))
+  assert.ok(room_manager.findRoomByJoinId("custom_myroom"))
+  assert.equal(room_manager.findRoomByJoinId("nope"), undefined)
+})
+
+test('sending to a disconnected player is a no-op', () => {
+  const player = make_player("Alice")
+  const socket = player.ws
+  player.detach_connection()
+
+  assert.equal(player.send({ type: 'anything' }), false)
+  assert.equal(socket.sent.length, 0)
+  assert.ok(player.last_disconnect_at instanceof Date)
+})
+
+test('a restore snapshot carries the replay messages for a live game', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { room, player_one } = make_started_room(room_manager)
+  room.handle_game_message(player_one, { type: 'game_message', action_type: 'move' })
+
+  const snapshot = build_player_state_snapshot(player_one, get_public_room_name)
+
+  assert.equal(snapshot.in_game, true)
+  assert.equal(snapshot.room_id, 'room')
+  assert.equal(snapshot.player_id, player_one.id)
+  assert.equal(snapshot.opponent_name, 'Bob')
+  assert.equal(snapshot.messages.length, 2)
+  assert.equal(snapshot.messages[0].type, 'game_start')
+  assert.equal(snapshot.messages[1].type, 'game_message')
+})
+
+test('a lobby snapshot has no room and no replay', () => {
+  const player = make_player("Alice")
+  const snapshot = build_player_state_snapshot(player, get_public_room_name)
+
+  assert.equal(snapshot.room_id, null)
+  assert.equal(snapshot.in_game, false)
+  assert.deepEqual(snapshot.messages, [])
+})
+
+test('handshake messages expose the restore credentials', () => {
+  const player = make_player("Alice")
+  const hello = build_server_hello_message(player)
+
+  assert.equal(hello.player_id, player.id)
+  assert.equal(hello.session_id, player.session_id)
+  assert.equal(hello.session_token, player.session_token)
+
+  const temporary = make_player("Temp")
+  const restored = build_session_restored_message(
+    player,
+    temporary,
+    build_player_state_snapshot(player, get_public_room_name)
+  )
+  assert.equal(restored.restored_player_id, player.id)
+  assert.equal(restored.removed_temporary_player_id, temporary.id)
+
+  const failed = build_session_restore_failed_message('no_matching_session')
+  assert.equal(failed.type, 'session_restore_failed')
+  assert.equal(failed.reason, 'no_matching_session')
+})
+
+test('player ids are unique uuids', () => {
+  const player_one = make_player("Alice")
+  const player_two = make_player("Bob")
+
+  assert.notEqual(player_one.id, player_two.id)
+  assert.match(player_one.id, /^[0-9a-f]{8}-[0-9a-f]{4}-/)
+  assert.notEqual(player_one.session_token, player_one.session_id)
+})
+
+// ---------------------------------------------------------------------------
+// Queue manager
+// ---------------------------------------------------------------------------
+
+const server_config = {
+  decks: [
+    { character: "ryu", season: 1 },
+    { character: "nanase", season: 3 },
+  ],
+  queue_config: [
+    {
+      id: "all",
+      name: "All Seasons",
+      season_restriction: { min: 1, max: 9 },
+      custom_allowed: true,
+      banned: [],
+      starting_timer: 900,
+      enforce_timer: false,
+      minimum_time_per_choice: 30,
+    },
+    {
+      id: "s1",
+      name: "Season 1",
+      season_restriction: { min: 1, max: 1 },
+      custom_allowed: false,
+      banned: ["ryu"],
+      starting_timer: 900,
+      enforce_timer: false,
+      minimum_time_per_choice: 30,
+    },
+  ],
+}
+
+function make_queue_manager() {
+  const room_manager = new RoomManager(GRACE_MS)
+  const discord_connection = { sendMatchmakingNotification: () => {} }
+  const queue_manager = new QueueManager(database, server_config, discord_connection, room_manager)
+  return { queue_manager, room_manager }
+}
+
+test('alternate skins validate against their base character', () => {
+  const { queue_manager } = make_queue_manager()
+
+  assert.equal(queue_manager.validateDeck("all", "nanase"), true)
+  assert.equal(queue_manager.validateDeck("all", "nanase_2"), true)
+  assert.equal(queue_manager.validateDeck("s1", "nanase_2"), false, 'skins inherit the season')
+  assert.equal(queue_manager.validateDeck("s1", "ryu_3"), false, 'skins inherit the ban list')
+  assert.equal(queue_manager.validateDeck("all", "not_a_character"), false)
+})
+
+test('the queue advertises the character that is waiting', () => {
+  const { queue_manager } = make_queue_manager()
+  const player = make_player("Alice", "random_s1#ryu")
+
+  assert.equal(queue_manager.addPlayer("all", player, "test"), true)
+
+  const queue_info = queue_manager.getQueueInfos().find(queue => queue.id === "all")
+  assert.equal(queue_info.match_available, true)
+  assert.equal(queue_info.waiting_deck_id, "ryu", 'random picks are normalized')
+  assert.equal(player.queue_id, "all")
+})
+
+test('a dropped queued player stops advertising an unjoinable match', () => {
+  const { queue_manager, room_manager } = make_queue_manager()
+  const player = make_player("Alice", "ryu")
+  queue_manager.addPlayer("all", player, "test")
+  const waiting_room_name = queue_manager.getQueueById("all").waiting_room.name
+
+  player.detach_connection()
+  queue_manager.pruneStaleQueues(is_alive)
+
+  assert.equal(queue_manager.getQueueById("all").waiting_room, null)
+  assert.equal(room_manager.findRoom(waiting_room_name), undefined)
+  assert.equal(player.queue_id, null, 'a pruned player does not keep a queue reference')
+  assert.equal(queue_manager.getQueueInfos().find(queue => queue.id === "all").match_available, false)
+})
+
+test('leaving the queue clears the waiting room and the queue id', () => {
+  const { queue_manager, room_manager } = make_queue_manager()
+  const player = make_player("Alice", "ryu")
+  queue_manager.addPlayer("all", player, "test")
+  const waiting_room_name = queue_manager.getQueueById("all").waiting_room.name
+
+  queue_manager.leaveRoom(player)
+
+  assert.equal(queue_manager.getQueueById("all").waiting_room, null)
+  assert.equal(room_manager.findRoom(waiting_room_name), undefined)
+  assert.equal(player.queue_id, null)
+})

--- a/test/reconnect.test.js
+++ b/test/reconnect.test.js
@@ -251,6 +251,28 @@ test('a restore snapshot carries the replay messages for a live game', () => {
   assert.equal(snapshot.messages[1].type, 'game_message')
 })
 
+test('a restore snapshot reports how long the opponent has left to reconnect', () => {
+  const room_manager = new RoomManager(GRACE_MS)
+  const { room, player_one, player_two } = make_started_room(room_manager)
+
+  // Opponent still present: there is no held seat, so there is no deadline.
+  const connected_snapshot = build_player_state_snapshot(player_one, get_public_room_name, GRACE_MS)
+  assert.equal(connected_snapshot.opponent_connected, true)
+  assert.equal(connected_snapshot.opponent_reconnect_deadline, null)
+
+  player_two.connected = false
+  player_two.last_disconnect_at = new Date()
+  room.hold_seat_for_reconnect(player_two, GRACE_MS)
+
+  const snapshot = build_player_state_snapshot(player_one, get_public_room_name, GRACE_MS)
+  assert.equal(snapshot.opponent_connected, false)
+  assert.equal(
+    snapshot.opponent_reconnect_deadline,
+    player_two.last_disconnect_at.getTime() + GRACE_MS,
+    'the restoring client needs the same deadline the peers were broadcast'
+  )
+})
+
 test('a lobby snapshot has no room and no replay', () => {
   const player = make_player("Alice")
   const snapshot = build_player_state_snapshot(player, get_public_room_name)

--- a/test/session_restore.integration.test.js
+++ b/test/session_restore.integration.test.js
@@ -1,0 +1,252 @@
+// End to end coverage of the reconnect flow: it boots the real server, drops a
+// player mid game, and proves a new websocket can reclaim the seat with the
+// session token alone.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import WebSocket from 'ws'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const server_path = path.join(__dirname, '..', 'server.js')
+const PORT = 8099
+const SERVER_URL = `ws://localhost:${PORT}`
+
+function start_server() {
+  const child = spawn(process.execPath, [server_path], {
+    cwd: path.join(__dirname, '..'),
+    env: {
+      ...process.env,
+      PORT: String(PORT),
+      SKIP_MATCH_UPLOAD: '1',
+      CHECK_VALUE: '',
+      RECONNECT_GRACE_MS: '60000',
+      KEEPALIVE_INTERVAL_MS: '60000',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('server did not start in time')), 30000)
+    child.stdout.on('data', (chunk) => {
+      if (chunk.toString().includes('Server started on port')) {
+        clearTimeout(timer)
+        resolve(child)
+      }
+    })
+    child.on('error', reject)
+  })
+}
+
+class TestClient {
+  constructor() {
+    this.messages = []
+    this.waiters = []
+  }
+
+  static async connect() {
+    const client = new TestClient()
+    client.ws = new WebSocket(SERVER_URL)
+    client.ws.on('message', (data) => {
+      const message = JSON.parse(data)
+      const waiter = client.waiters.find(candidate => candidate.type === message.type)
+      if (waiter) {
+        client.waiters.splice(client.waiters.indexOf(waiter), 1)
+        clearTimeout(waiter.timer)
+        waiter.resolve(message)
+        return
+      }
+      client.messages.push(message)
+    })
+    await once(client.ws, 'open')
+    return client
+  }
+
+  send(message) {
+    this.ws.send(JSON.stringify(message))
+  }
+
+  wait_for(type, timeout_ms = 5000) {
+    const existing = this.messages.find(message => message.type === type)
+    if (existing) {
+      this.messages.splice(this.messages.indexOf(existing), 1)
+      return Promise.resolve(existing)
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        type,
+        resolve,
+        timer: setTimeout(() => {
+          this.waiters.splice(this.waiters.indexOf(waiter), 1)
+          reject(new Error(`timed out waiting for ${type}`))
+        }, timeout_ms),
+      }
+      this.waiters.push(waiter)
+    })
+  }
+}
+
+function join_room_payload(player_name) {
+  return {
+    type: 'join_room',
+    room_id: 'reconnect_test_room',
+    deck_id: 'ryu',
+    version: 'dev_test',
+    player_name,
+    custom_deck_definition: null,
+  }
+}
+
+test('a dropped player reclaims their seat with the session token', async (t) => {
+  const server = await start_server()
+  const clients = []
+  t.after(async () => {
+    for (const client of clients) {
+      try {
+        client.ws.terminate()
+      } catch {}
+    }
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const alice = await TestClient.connect()
+  clients.push(alice)
+  const alice_hello = await alice.wait_for('server_hello')
+  assert.ok(alice_hello.session_token, 'server_hello carries a session token')
+  assert.ok(alice_hello.session_id)
+  assert.match(alice_hello.player_id, /^[0-9a-f]{8}-/, 'player ids are uuids')
+
+  alice.send(join_room_payload('Alice'))
+  await alice.wait_for('room_waiting_for_opponent')
+
+  const bob = await TestClient.connect()
+  clients.push(bob)
+  await bob.wait_for('server_hello')
+  bob.send(join_room_payload('Bob'))
+
+  const alice_game_start = await alice.wait_for('game_start')
+  await bob.wait_for('game_start')
+  assert.equal(alice_game_start.your_player_id, alice_hello.player_id)
+
+  // Drop Alice the way a real network failure would.
+  alice.ws.terminate()
+
+  const pending = await bob.wait_for('player_disconnect_pending')
+  assert.equal(pending.player_id, alice_hello.player_id)
+  assert.ok(pending.reconnect_deadline > Date.now())
+
+  // A brand new connection restores the old session.
+  const alice_again = await TestClient.connect()
+  clients.push(alice_again)
+  const temporary_hello = await alice_again.wait_for('server_hello')
+  assert.notEqual(temporary_hello.player_id, alice_hello.player_id)
+
+  alice_again.send({
+    type: 'restore_session',
+    context: {
+      previous_session_token: alice_hello.session_token,
+      previous_session_id: alice_hello.session_id,
+      previous_player_id: alice_hello.player_id,
+    },
+  })
+
+  const restored = await alice_again.wait_for('session_restored')
+  assert.equal(restored.player_id, alice_hello.player_id, 'the original uuid is preserved')
+  assert.equal(restored.session_token, alice_hello.session_token)
+  assert.equal(restored.removed_temporary_player_id, temporary_hello.player_id)
+  assert.equal(restored.in_game, true)
+  assert.equal(restored.room_id, 'reconnect_test_room')
+  assert.equal(restored.opponent_name, 'Bob')
+  assert.equal(restored.messages[0].type, 'game_start')
+
+  await bob.wait_for('player_reconnect')
+
+  // The restored socket owns the seat: its game messages still reach Bob.
+  alice_again.send({ type: 'game_message', action_type: 'test_action' })
+  const relayed = await bob.wait_for('game_message')
+  assert.equal(relayed.action_type, 'test_action')
+
+  // Only one identity is online.
+  bob.send({ type: 'request_players_update' })
+  const players_update = await bob.wait_for('players_update')
+  const alice_entries = players_update.players.filter(entry => entry.player_name === 'Alice')
+  assert.equal(alice_entries.length, 1, 'the temporary identity is gone')
+  assert.equal(alice_entries[0].player_id, alice_hello.player_id)
+})
+
+test('a lobby session survives a reconnect', async (t) => {
+  const server = await start_server()
+  const clients = []
+  t.after(async () => {
+    for (const client of clients) {
+      try {
+        client.ws.terminate()
+      } catch {}
+    }
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const client = await TestClient.connect()
+  clients.push(client)
+  const hello = await client.wait_for('server_hello')
+  client.send({ type: 'set_name', player_name: 'Alice', version: 'dev_test' })
+  await client.wait_for('name_update')
+
+  client.ws.terminate()
+
+  const reconnected = await TestClient.connect()
+  clients.push(reconnected)
+  await reconnected.wait_for('server_hello')
+  reconnected.send({
+    type: 'restore_session',
+    context: { previous_session_token: hello.session_token },
+  })
+
+  const restored = await reconnected.wait_for('session_restored')
+  assert.equal(restored.player_id, hello.player_id)
+  assert.equal(restored.player_name, 'Alice', 'the name survives the reconnect')
+  assert.equal(restored.in_game, false)
+  assert.equal(restored.room_id, null)
+  assert.deepEqual(restored.messages, [])
+})
+
+test('restore is rejected without a valid session token', async (t) => {
+  const server = await start_server()
+  const clients = []
+  t.after(async () => {
+    for (const client of clients) {
+      try {
+        client.ws.terminate()
+      } catch {}
+    }
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const client = await TestClient.connect()
+  clients.push(client)
+  const hello = await client.wait_for('server_hello')
+
+  client.send({ type: 'restore_session', context: { previous_session_token: 'not-a-real-token' } })
+  const unknown_token = await client.wait_for('session_restore_failed')
+  assert.equal(unknown_token.reason, 'no_matching_session')
+
+  client.send({ type: 'restore_session', context: { player_name: 'Alice', room_id: 'anything' } })
+  const no_token = await client.wait_for('session_restore_failed')
+  assert.equal(no_token.reason, 'missing_session_token', 'name and room are not match keys')
+
+  // A token that disagrees with the rest of the saved state is refused.
+  client.send({
+    type: 'restore_session',
+    context: {
+      previous_session_token: hello.session_token,
+      previous_player_id: 'some-other-player',
+    },
+  })
+  const mismatch = await client.wait_for('session_restore_failed')
+  assert.equal(mismatch.reason, 'session_mismatch')
+})

--- a/test/session_restore_edge.integration.test.js
+++ b/test/session_restore_edge.integration.test.js
@@ -1,0 +1,210 @@
+// Additional end to end coverage for reconnect edge cases that the primary
+// integration suite does not exercise: websocket takeover when the original
+// connection is still live, the session_id consistency check, and the
+// grace-expiry terminal disconnect the opponent observes.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import WebSocket from 'ws'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const server_path = path.join(__dirname, '..', 'server.js')
+const PORT = 8100
+const SERVER_URL = `ws://localhost:${PORT}`
+
+function start_server(extra_env = {}) {
+  const child = spawn(process.execPath, [server_path], {
+    cwd: path.join(__dirname, '..'),
+    env: {
+      ...process.env,
+      PORT: String(PORT),
+      SKIP_MATCH_UPLOAD: '1',
+      CHECK_VALUE: '',
+      RECONNECT_GRACE_MS: '60000',
+      KEEPALIVE_INTERVAL_MS: '60000',
+      ...extra_env,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('server did not start in time')), 30000)
+    child.stdout.on('data', (chunk) => {
+      if (chunk.toString().includes('Server started on port')) {
+        clearTimeout(timer)
+        resolve(child)
+      }
+    })
+    child.on('error', reject)
+  })
+}
+
+class TestClient {
+  constructor() {
+    this.messages = []
+    this.waiters = []
+  }
+
+  static async connect() {
+    const client = new TestClient()
+    client.ws = new WebSocket(SERVER_URL)
+    client.ws.on('message', (data) => {
+      const message = JSON.parse(data)
+      const waiter = client.waiters.find(candidate => candidate.type === message.type)
+      if (waiter) {
+        client.waiters.splice(client.waiters.indexOf(waiter), 1)
+        clearTimeout(waiter.timer)
+        waiter.resolve(message)
+        return
+      }
+      client.messages.push(message)
+    })
+    await once(client.ws, 'open')
+    return client
+  }
+
+  send(message) {
+    this.ws.send(JSON.stringify(message))
+  }
+
+  wait_for(type, timeout_ms = 5000) {
+    const existing = this.messages.find(message => message.type === type)
+    if (existing) {
+      this.messages.splice(this.messages.indexOf(existing), 1)
+      return Promise.resolve(existing)
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        type,
+        resolve,
+        timer: setTimeout(() => {
+          this.waiters.splice(this.waiters.indexOf(waiter), 1)
+          reject(new Error(`timed out waiting for ${type}`))
+        }, timeout_ms),
+      }
+      this.waiters.push(waiter)
+    })
+  }
+}
+
+function join_room_payload(player_name) {
+  return {
+    type: 'join_room',
+    room_id: 'reconnect_edge_room',
+    deck_id: 'ryu',
+    version: 'dev_test',
+    player_name,
+    custom_deck_definition: null,
+  }
+}
+
+test('restoring a live session replaces the older still-connected socket', async (t) => {
+  const server = await start_server()
+  const clients = []
+  t.after(async () => {
+    for (const client of clients) {
+      try {
+        client.ws.terminate()
+      } catch {}
+    }
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const alice = await TestClient.connect()
+  clients.push(alice)
+  const hello = await alice.wait_for('server_hello')
+  alice.send({ type: 'set_name', player_name: 'Alice', version: 'dev_test' })
+  await alice.wait_for('name_update')
+
+  // A duplicate tab that presents the same token while the original is still
+  // open should take over: the token holder wins and the old socket is closed.
+  const duplicate = await TestClient.connect()
+  clients.push(duplicate)
+  const dup_hello = await duplicate.wait_for('server_hello')
+  assert.notEqual(dup_hello.player_id, hello.player_id)
+
+  duplicate.send({
+    type: 'restore_session',
+    context: { previous_session_token: hello.session_token },
+  })
+
+  const restored = await duplicate.wait_for('session_restored')
+  assert.equal(restored.player_id, hello.player_id)
+  assert.equal(restored.removed_temporary_player_id, dup_hello.player_id)
+
+  // The original socket is force-closed by the takeover.
+  await once(alice.ws, 'close')
+  assert.equal(alice.ws.readyState, WebSocket.CLOSED)
+})
+
+test('a token that disagrees with the saved session id is refused', async (t) => {
+  const server = await start_server()
+  const clients = []
+  t.after(async () => {
+    for (const client of clients) {
+      try {
+        client.ws.terminate()
+      } catch {}
+    }
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const client = await TestClient.connect()
+  clients.push(client)
+  const hello = await client.wait_for('server_hello')
+
+  client.send({
+    type: 'restore_session',
+    context: {
+      previous_session_token: hello.session_token,
+      previous_session_id: 'some-other-session-id',
+    },
+  })
+
+  const failed = await client.wait_for('session_restore_failed')
+  assert.equal(failed.reason, 'session_mismatch')
+  assert.equal(failed.field, 'previous_session_id')
+})
+
+test('a seat left unclaimed past the grace period ends the opponent game', async (t) => {
+  const server = await start_server({ RECONNECT_GRACE_MS: '1000' })
+  const clients = []
+  t.after(async () => {
+    for (const client of clients) {
+      try {
+        client.ws.terminate()
+      } catch {}
+    }
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const alice = await TestClient.connect()
+  clients.push(alice)
+  const alice_hello = await alice.wait_for('server_hello')
+  alice.send(join_room_payload('Alice'))
+  await alice.wait_for('room_waiting_for_opponent')
+
+  const bob = await TestClient.connect()
+  clients.push(bob)
+  await bob.wait_for('server_hello')
+  bob.send(join_room_payload('Bob'))
+  await alice.wait_for('game_start')
+  await bob.wait_for('game_start')
+
+  // Drop Alice and never come back; the grace period lapses.
+  alice.ws.terminate()
+  const pending = await bob.wait_for('player_disconnect_pending')
+  assert.equal(pending.player_id, alice_hello.player_id)
+
+  // The server sweep eventually expires the held seat and the opponent sees a
+  // terminal player_disconnect with the reconnect_timeout reason.
+  const terminal = await bob.wait_for('player_disconnect', 15000)
+  assert.equal(terminal.reason, 'reconnect_timeout')
+  assert.equal(terminal.player_id, alice_hello.player_id)
+})

--- a/test/session_restore_stale.integration.test.js
+++ b/test/session_restore_stale.integration.test.js
@@ -1,0 +1,524 @@
+// End to end coverage for stale session handling. The client persists its
+// session token and replays it on the next launch, so the server's answer to
+// "is this session still worth restoring?" decides whether a player is dumped
+// back into a match that nobody is playing any more.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import WebSocket from 'ws'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const server_path = path.join(__dirname, '..', 'server.js')
+const PORT = 8101
+const SERVER_URL = `ws://localhost:${PORT}`
+
+function start_server(extra_env = {}) {
+  const child = spawn(process.execPath, [server_path], {
+    cwd: path.join(__dirname, '..'),
+    env: {
+      ...process.env,
+      PORT: String(PORT),
+      SKIP_MATCH_UPLOAD: '1',
+      CHECK_VALUE: '',
+      RECONNECT_GRACE_MS: '60000',
+      KEEPALIVE_INTERVAL_MS: '60000',
+      ...extra_env,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('server did not start in time')), 30000)
+    child.stdout.on('data', (chunk) => {
+      if (chunk.toString().includes('Server started on port')) {
+        clearTimeout(timer)
+        resolve(child)
+      }
+    })
+    child.on('error', reject)
+  })
+}
+
+class TestClient {
+  constructor() {
+    this.messages = []
+    this.waiters = []
+  }
+
+  static async connect() {
+    const client = new TestClient()
+    client.ws = new WebSocket(SERVER_URL)
+    client.ws.on('message', (data) => {
+      const message = JSON.parse(data)
+      const waiter = client.waiters.find(candidate => candidate.type === message.type)
+      if (waiter) {
+        client.waiters.splice(client.waiters.indexOf(waiter), 1)
+        clearTimeout(waiter.timer)
+        waiter.resolve(message)
+        return
+      }
+      client.messages.push(message)
+    })
+    await once(client.ws, 'open')
+    return client
+  }
+
+  send(message) {
+    this.ws.send(JSON.stringify(message))
+  }
+
+  has_received(type) {
+    return this.messages.some(message => message.type === type)
+  }
+
+  // The server broadcasts players_update unprompted, so a buffered copy from
+  // before an action would otherwise satisfy a later wait_for.
+  forget(type) {
+    this.messages = this.messages.filter(message => message.type !== type)
+  }
+
+  wait_for(type, timeout_ms = 5000) {
+    const existing = this.messages.find(message => message.type === type)
+    if (existing) {
+      this.messages.splice(this.messages.indexOf(existing), 1)
+      return Promise.resolve(existing)
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        type,
+        resolve,
+        timer: setTimeout(() => {
+          this.waiters.splice(this.waiters.indexOf(waiter), 1)
+          reject(new Error(`timed out waiting for ${type}`))
+        }, timeout_ms),
+      }
+      this.waiters.push(waiter)
+    })
+  }
+}
+
+const ROOM = 'stale_session_room'
+
+function join_room_payload(player_name) {
+  return {
+    type: 'join_room',
+    room_id: ROOM,
+    deck_id: 'ryu',
+    version: 'dev_test',
+    player_name,
+    custom_deck_definition: null,
+  }
+}
+
+function restore_payload(hello) {
+  return {
+    type: 'restore_session',
+    context: {
+      previous_session_token: hello.session_token,
+      previous_session_id: hello.session_id,
+      previous_player_id: hello.player_id,
+    },
+  }
+}
+
+function make_harness(t, clients) {
+  t.after(async () => {
+    for (const client of clients) {
+      try {
+        client.ws.terminate()
+      } catch {}
+    }
+  })
+}
+
+// Starts a match and returns both clients plus their server_hello messages.
+async function start_match(clients) {
+  const alice = await TestClient.connect()
+  clients.push(alice)
+  const alice_hello = await alice.wait_for('server_hello')
+  alice.send(join_room_payload('Alice'))
+  await alice.wait_for('room_waiting_for_opponent')
+
+  const bob = await TestClient.connect()
+  clients.push(bob)
+  const bob_hello = await bob.wait_for('server_hello')
+  bob.send(join_room_payload('Bob'))
+
+  await alice.wait_for('game_start')
+  await bob.wait_for('game_start')
+  return { alice, alice_hello, bob, bob_hello }
+}
+
+test('leaving the room cleanly means a later restore does not rejoin the match', async (t) => {
+  const server = await start_server()
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const { alice, alice_hello, bob } = await start_match(clients)
+
+  // Both players quit back to the lobby, then close the client.
+  alice.send({ type: 'leave_room' })
+  bob.send({ type: 'leave_room' })
+  await new Promise(resolve => setTimeout(resolve, 300))
+  alice.ws.close()
+  bob.ws.close()
+  await new Promise(resolve => setTimeout(resolve, 300))
+
+  // Relaunching the client replays the stored token.
+  const relaunched = await TestClient.connect()
+  clients.push(relaunched)
+  await relaunched.wait_for('server_hello')
+  relaunched.send(restore_payload(alice_hello))
+
+  const restored = await relaunched.wait_for('session_restored')
+  assert.equal(restored.player_id, alice_hello.player_id, 'the identity is still reclaimed')
+  assert.equal(restored.in_game, false, 'a player who left should not be put back in a game')
+  assert.equal(restored.room_id, null, 'a player who left should not be back in the room')
+  assert.deepEqual(restored.messages, [], 'there is no game log to replay')
+  assert.equal(restored.opponent_name, null, 'there is no opponent to wait for')
+})
+
+test('a session abandoned mid match expires once the grace period passes', async (t) => {
+  const server = await start_server({ RECONNECT_GRACE_MS: '250', SESSION_GRACE_MS: '250' })
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const { alice, alice_hello, bob } = await start_match(clients)
+
+  // Both clients vanish mid game, the way closing two debugger windows does.
+  alice.ws.terminate()
+  bob.ws.terminate()
+  await new Promise(resolve => setTimeout(resolve, 800))
+
+  const relaunched = await TestClient.connect()
+  clients.push(relaunched)
+  await relaunched.wait_for('server_hello')
+  relaunched.send(restore_payload(alice_hello))
+
+  const failure = await relaunched.wait_for('session_restore_failed')
+  assert.equal(failure.reason, 'no_matching_session',
+    'an abandoned match must not be resurrected after the grace period')
+})
+
+test('a match abandoned by every player is over rather than left as a ghost', async (t) => {
+  const server = await start_server({ RECONNECT_GRACE_MS: '60000' })
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const { alice, alice_hello, bob } = await start_match(clients)
+  alice.ws.terminate()
+  bob.ws.terminate()
+  await new Promise(resolve => setTimeout(resolve, 300))
+
+  const relaunched = await TestClient.connect()
+  clients.push(relaunched)
+  await relaunched.wait_for('server_hello')
+  relaunched.send(restore_payload(alice_hello))
+
+  const restored = await relaunched.wait_for('session_restored')
+  // Nobody was left in the room, so there is no match to wait for. Reporting
+  // it as live strands the returning player in a "waiting for opponent"
+  // overlay for a game neither player is coming back to. Ending the match also
+  // lets the next sweep release both held seats and delete the room, so the
+  // player simply lands back in the lobby.
+  assert.equal(restored.in_game, false,
+    'a room where everyone disconnected is not a live match')
+  assert.equal(restored.room_id, null, 'the dead room was cleaned up')
+  assert.equal(restored.opponent_name, null, 'there is no opponent to wait for')
+})
+
+test('a restoring client is told how long the opponent has left to reconnect', async (t) => {
+  const GRACE_MS = 60000
+  const server = await start_server({ RECONNECT_GRACE_MS: String(GRACE_MS) })
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const { alice, bob, bob_hello } = await start_match(clients)
+
+  // Alice drops mid match, so her seat is held and Bob sees a live deadline.
+  const dropped_at = Date.now()
+  alice.ws.terminate()
+  const pending = await bob.wait_for('player_disconnect_pending')
+  assert.equal(typeof pending.reconnect_deadline, 'number',
+    'the peer broadcast must carry the deadline the overlay counts down to')
+  const broadcast_lead_ms = pending.reconnect_deadline - dropped_at
+  assert.ok(broadcast_lead_ms > GRACE_MS - 5000 && broadcast_lead_ms <= GRACE_MS + 1000,
+    `expected roughly ${GRACE_MS}ms of grace, got ${broadcast_lead_ms}ms`)
+
+  // Bob relaunches while his original connection is still up (the seat is
+  // taken over rather than vacated), so the room keeps a player present and
+  // Alice's held seat stays live. Bob missed the broadcast, so the restore
+  // snapshot has to tell him the same thing.
+  const relaunched = await TestClient.connect()
+  clients.push(relaunched)
+  await relaunched.wait_for('server_hello')
+  relaunched.send(restore_payload(bob_hello))
+
+  const restored = await relaunched.wait_for('session_restored')
+  assert.equal(restored.in_game, true)
+  assert.equal(restored.opponent_connected, false)
+  assert.equal(typeof restored.opponent_reconnect_deadline, 'number',
+    'a client that missed the broadcast still needs the deadline')
+  assert.ok(Math.abs(restored.opponent_reconnect_deadline - pending.reconnect_deadline) < 1000,
+    'both paths must agree on when the seat expires')
+
+  const remaining_seconds = Math.ceil((restored.opponent_reconnect_deadline - Date.now()) / 1000)
+  assert.ok(remaining_seconds > 0 && remaining_seconds <= GRACE_MS / 1000,
+    `countdown should be displayable, got ${remaining_seconds}s`)
+})
+
+test('a restoring client sees no reconnect deadline when the opponent is present', async (t) => {
+  const server = await start_server({ RECONNECT_GRACE_MS: '60000' })
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const { bob, bob_hello } = await start_match(clients)
+  bob.ws.terminate()
+  await new Promise(resolve => setTimeout(resolve, 300))
+
+  const relaunched = await TestClient.connect()
+  clients.push(relaunched)
+  await relaunched.wait_for('server_hello')
+  relaunched.send(restore_payload(bob_hello))
+
+  const restored = await relaunched.wait_for('session_restored')
+  assert.equal(restored.opponent_connected, true, 'Alice never left')
+  assert.equal(restored.opponent_reconnect_deadline, null,
+    'no seat is being held, so there is nothing to count down')
+})
+
+// The user's report: closing every debugger instance mid match and relaunching
+// dropped them straight back into a ghost match with an inescapable "waiting
+// for opponent" overlay, even though nobody was connected to the server.
+test('one player dropping does not end a match the other is still playing', async (t) => {
+  const server = await start_server({ RECONNECT_GRACE_MS: '60000' })
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const { alice, alice_hello, bob } = await start_match(clients)
+  alice.ws.terminate()
+  await bob.wait_for('player_disconnect_pending')
+
+  // Bob is still sitting in the match, so Alice's seat must stay reclaimable.
+  const relaunched = await TestClient.connect()
+  clients.push(relaunched)
+  await relaunched.wait_for('server_hello')
+  relaunched.send(restore_payload(alice_hello))
+
+  const restored = await relaunched.wait_for('session_restored')
+  assert.equal(restored.in_game, true)
+  assert.equal(restored.game_over, false,
+    'a match with a player still present is very much alive')
+  assert.equal(restored.opponent_connected, true)
+})
+
+// The user's report: a match ended because one player used Leave Match, then
+test('a survivor of an opponent quit is not restored into a dead match', async (t) => {
+  const server = await start_server({ RECONNECT_GRACE_MS: '60000' })
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const { alice, bob, bob_hello } = await start_match(clients)
+
+  // Alice leaves the match cleanly, which ends it for Bob.
+  alice.send({ type: 'leave_room' })
+  await bob.wait_for('player_quit')
+
+  // Bob's client is then closed, the way shutting the debugger does.
+  bob.ws.terminate()
+  await new Promise(resolve => setTimeout(resolve, 400))
+
+  const relaunched = await TestClient.connect()
+  clients.push(relaunched)
+  await relaunched.wait_for('server_hello')
+  relaunched.send(restore_payload(bob_hello))
+
+  const restored = await relaunched.wait_for('session_restored')
+  assert.equal(restored.in_game, false,
+    'there is no match left to rejoin once the only opponent quit')
+  assert.equal(restored.room_id, null, 'the dead room must not be rejoined')
+  assert.equal(restored.opponent_name, null, 'there is nobody to wait for')
+  assert.notEqual(restored.opponent_connected, false,
+    'reporting a disconnected opponent triggers a bogus reconnect overlay')
+  assert.equal(restored.opponent_reconnect_deadline, null,
+    'a dead match must not advertise a reconnect deadline')
+})
+
+test('a started room with only one player left is over', async (t) => {
+  const server = await start_server({ RECONNECT_GRACE_MS: '60000' })
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const { alice, bob, bob_hello } = await start_match(clients)
+  alice.send({ type: 'leave_room' })
+  await bob.wait_for('player_quit')
+
+  // Because the match is already over, Bob dropping must be a plain quit
+  // rather than a held seat, so his peers are never told to wait for him.
+  bob.ws.terminate()
+  await new Promise(resolve => setTimeout(resolve, 400))
+
+  const relaunched = await TestClient.connect()
+  clients.push(relaunched)
+  await relaunched.wait_for('server_hello')
+  relaunched.send(restore_payload(bob_hello))
+  const restored = await relaunched.wait_for('session_restored')
+  assert.deepEqual(restored.messages, [],
+    'a dead match should not replay a game log on restore')
+})
+
+// Two windows or tabs share one stored identity, so both replay the same token
+// on launch. Without an explicit notice the loser sees a bare socket close,
+// treats it as a network blip, reconnects, steals the session back, and the two
+// clients disconnect each other forever.
+test('the connection that loses a session is told why', async (t) => {
+  const server = await start_server()
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const first = await TestClient.connect()
+  clients.push(first)
+  const hello = await first.wait_for('server_hello')
+
+  const second = await TestClient.connect()
+  clients.push(second)
+  await second.wait_for('server_hello')
+  second.send(restore_payload(hello))
+
+  const replaced = await first.wait_for('session_replaced')
+  assert.equal(replaced.reason, 'opened_elsewhere')
+  assert.equal(replaced.player_id, hello.player_id,
+    'the loser needs to know which identity it lost')
+
+  const restored = await second.wait_for('session_restored')
+  assert.equal(restored.player_id, hello.player_id, 'the newer connection wins')
+})
+
+test('an unknown session token fails cleanly and leaves the connection usable', async (t) => {
+  const server = await start_server()
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const client = await TestClient.connect()
+  clients.push(client)
+  const hello = await client.wait_for('server_hello')
+
+  client.send({
+    type: 'restore_session',
+    context: { previous_session_token: 'not-a-real-token' },
+  })
+  const failure = await client.wait_for('session_restore_failed')
+  assert.equal(failure.reason, 'no_matching_session')
+
+  // The throwaway identity must survive, otherwise the client is stranded.
+  client.send(join_room_payload('Alice'))
+  await client.wait_for('room_waiting_for_opponent')
+
+  client.forget('players_update')
+  client.send({ type: 'request_players_update' })
+  const update = await client.wait_for('players_update')
+  assert.ok(update.players.some(entry => entry.player_name === 'Alice'),
+    'the client can still play after a failed restore')
+  assert.ok(hello.session_token)
+})
+
+test('a token that disagrees with the stored player id is rejected', async (t) => {
+  const server = await start_server()
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const alice = await TestClient.connect()
+  clients.push(alice)
+  const alice_hello = await alice.wait_for('server_hello')
+  alice.ws.close()
+  await new Promise(resolve => setTimeout(resolve, 200))
+
+  const relaunched = await TestClient.connect()
+  clients.push(relaunched)
+  await relaunched.wait_for('server_hello')
+  relaunched.send({
+    type: 'restore_session',
+    context: {
+      previous_session_token: alice_hello.session_token,
+      previous_player_id: 'a-different-player',
+    },
+  })
+
+  const failure = await relaunched.wait_for('session_restore_failed')
+  assert.equal(failure.reason, 'session_mismatch')
+  assert.equal(failure.field, 'previous_player_id')
+})
+
+test('restoring into a room the opponent already left does not report a live opponent', async (t) => {
+  const server = await start_server()
+  const clients = []
+  make_harness(t, clients)
+  t.after(async () => {
+    server.kill()
+    await once(server, 'exit')
+  })
+
+  const { alice, alice_hello, bob } = await start_match(clients)
+
+  // Bob quits for good while Alice merely drops off the network.
+  bob.send({ type: 'leave_room' })
+  await new Promise(resolve => setTimeout(resolve, 300))
+  alice.ws.terminate()
+  await new Promise(resolve => setTimeout(resolve, 300))
+
+  const relaunched = await TestClient.connect()
+  clients.push(relaunched)
+  await relaunched.wait_for('server_hello')
+  relaunched.send(restore_payload(alice_hello))
+
+  const restored = await relaunched.wait_for('session_restored')
+  assert.notEqual(restored.opponent_connected, true,
+    'an opponent who quit must never look connected')
+})


### PR DESCRIPTION
Ports the reconnect feature from the Chinese fork (`exceedserver_china`), redesigned around a token-only trust model, plus the small independent wins from that fork.

## Reconnecting

A websocket connection and a player session are now separate things. A player object outlives its socket, so a client that drops mid game can come back and reclaim its seat.

There are no accounts, so the server cannot recognise a returning client on its own. Instead it mints a credential the client persists and presents on reconnect:

- `server_hello` and `name_update` now carry `player_id` (uuid), `session_id` (public) and `session_token` (**secret**).
- On reconnect the client sends `restore_session { context: { previous_session_token } }`.
- The server does an O(1) lookup and rebinds the new socket onto the original player object, preserving the id, the room and the seat.
- `session_restored` returns `room_id`, `in_game`, `queue_id`, `lobby_state`, `opponent_name`, `opponent_connected` and a `messages` replay array (`game_start` plus every `game_message`), which is everything the client needs to rebuild an in progress game and resume with no user interaction.

The token is the **only** match key. Names, room ids and IP addresses are never used to identify a session, and only the token holder can reclaim a seat. `previous_player_id` / `previous_session_id` are accepted purely as consistency checks.

## Disconnect handling

| Event | Message | Sent to |
| --- | --- | --- |
| Connection drops mid game | `player_disconnect_pending` (with `reconnect_deadline`) | Opponent and observers |
| Restored in time | `player_reconnect` | Opponent and observers |
| Grace period expires | `player_disconnect` | The room |

The seat is held for `RECONNECT_GRACE_MS` (default 2 min) and nobody else can join it during that window. A deliberate `leave_room` is still immediate and never holds a seat.

Note this is intentionally **backwards compatible**: rather than repurposing `player_disconnect` the way the fork did, a drop emits a *new* `player_disconnect_pending`, and once grace expires clients receive the exact `player_disconnect` they already handle. Existing clients keep working unchanged; updated clients can show "opponent reconnecting...".

A periodic sweep detaches dead sockets, expires held seats, clears stale queue waiting rooms and garbage collects sessions. That also fixes ghost rooms and queues that could previously advertise unjoinable matches.

## Also ported from the fork

- Skin aware deck validation, so `nanase_2` inherits the season and ban status of `nanase`.
- `waiting_deck_id` on queue infos so the lobby can show which character is queued.
- `request_players_update` for an on demand lobby refresh.
- Websocket keepalive pings plus a `server_keepalive` message and a `ws.on('error')` handler, so half open connections are detected quickly.

## Deliberately not ported

- The Alibaba OSS / MySQL / CDN re-platforming, and the removal of the Discord notification and customs sync. Those are deployment specific to that fork.
- `request_matchlog_upload`, since we always upload.
- Stranger seat takeover (`reconnect_join`) and the `disconnect_confirmation_required` handshake. The first is a hijack vector; the second is a client race workaround the message design above makes unnecessary.
- The fork's fuzzy restore scoring, which could merge two players on a name plus room match with no token, and would force close an already live connection. Both were session hijack / remote kick vectors.

## Bugs fixed along the way

- `GameRoom.broadcast` mutated the shared message object, leaking the last player's `your_player_id` into the message log and into every observer's copy.
- `QueueManager.addPlayer` referenced an undefined `ws` on a version mismatch, throwing instead of reporting the error.
- `join_matchmaking` declared its `player` variable twice.
- `uuid` was imported by `gameroom.js` but missing from `package.json` dependencies, so it only resolved transitively.

## Testing

The repo had no tests. This adds `npm test` (`node --test test/`) with 24 passing tests:

- `test/reconnect.test.js` covers seat holding, grace expiry, sweeping, room and queue pruning, deck validation and the message builders.
- `test/session_restore.integration.test.js` boots the real server, drops a player mid game and proves a brand new websocket reclaims the seat with the token alone, that the restored socket's game messages still reach the opponent, that only one identity remains online, that a lobby session survives a reconnect, and that restores without a valid token are refused.

Also manually booted the server with short timers to confirm the sweep and keepalive intervals run cleanly while idle.

## Client impact

`player_id` is now a uuid string, so any client code comparing player ids numerically needs updating. The client side work is being investigated separately. `README.md` documents the full protocol.
